### PR TITLE
Revert "arm64 docker compatibility"

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,15 +32,6 @@ If you want to confirm that YCS is working, set the update time and the morning 
 
 *Note: The update time and any user ENVs that specify time for scheduled events are based on the host system time. However, times derived from astronomical events - sunset, twilight, etc. - are all in UTC. See [Road Map](#road-map).*
 
-#### arm64 Docker Instructions
-
-Run the following commands as root to clone, build, and run the Dockerfile.
-```
-git clone git://github.com/AdnanValdes/ycs
-docker build ./ -t ycs:arm
-docker run ycs:arm
-```
-
 ### Bare metal
 
 If you want to run YCS directly on your computer, make sure you have Python installed. Any 3.x version should work, although it has only been tested on Python 3.8+.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 yeelight==0.6.3
 schedule==1.1.0
-requests==2.26.0


### PR DESCRIPTION
This reverts commit e414fd0af772b0861d46991e4ef7b88e6b3a1c14.

ARM64 did not build correctly with this commit.